### PR TITLE
prune login/register returned data & token

### DIFF
--- a/controllers/userAuthController.js
+++ b/controllers/userAuthController.js
@@ -51,7 +51,11 @@ module.exports = {
 
 	findOne: async (req, res) => {
 		try {
-			const user = await User.findOne({ where: { email: req.body.email },  raw: true} )
+			const { dataValues: user } = await User.findOne({
+				where: { email: req.body.email },
+				include: [{ model: Role, as: "role" }],
+			})
+
 			if (user === null) {
 				res.json({ ok: false })
 			} else {

--- a/middlewares/authJWT.js
+++ b/middlewares/authJWT.js
@@ -3,7 +3,8 @@ const config = require("../config/authConfig.js");
 
 module.exports = {
   verifyToken: (req, res, next) => {
-    let token = req.headers["authorization"];
+    // Remove 'Bearer '
+    let token = req.headers?.authorization?.split(' ')[1];
 
     if (!token) {
       return res.status(403).send({
@@ -17,7 +18,8 @@ module.exports = {
           message: "Unauthorized!"
         });
       }
-      req.user = decoded.dataValues;
+
+      req.user = decoded;
       next();
     });
   }


### PR DESCRIPTION
* only use user `id` in JWT token
* return user data values instead of sequelize object
* remove hashed password from data returned
* fix token validation (remove 'Bear ' text)
* add error handling to sequelize
